### PR TITLE
chore(release): publish 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,185 +1,160 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [0.9.0](https://github.com/hidoo/unit-sass/compare/v0.8.0...v0.9.0) (2023-04-17)
+# [1.0.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.9.0...v1.0.0) (2024-04-30)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency fs-extra to v10.1.0 ([a4523a8](https://github.com/hidoo/unit-sass/commit/a4523a842a265b21df43dc2751161c7f588e0e5f))
+* **deps:** update dependency handlebars to v4.7.8 ([aabeeaf](https://github.com/hidoo/sassdoc-to-markdown/commit/aabeeafb60b482860e99a3b298209d20879def6c))
+
+
+* fix(deps)!: update dependency remark to v15 ([e697822](https://github.com/hidoo/sassdoc-to-markdown/commit/e697822a84ae5875caf038c11e4799f792f3af73))
+* fix!: import from @hidoo/unit monorepo ([87ea148](https://github.com/hidoo/sassdoc-to-markdown/commit/87ea148020d1cc66e92fd208c1b994fa96547be8))
+
+
+### BREAKING CHANGES
+
+* Remove remarkParserOption and add remarkGfmOptions in options of sassdoc2md.
+* Drop Node.js 14.x and 16.x support. Requires ES Modules.
 
 
 
-
-
-# [0.8.0](https://github.com/hidoo/unit-sass/compare/v0.7.0...v0.8.0) (2022-07-13)
-
-
-### Bug Fixes
-
-* **deps:** update dependency glob to v7.2.3 ([0fe028d](https://github.com/hidoo/unit-sass/commit/0fe028d939f2592945ed978a70a75279f24344dc))
-* **deps:** update dependency sassdoc to v2.7.4 ([739ef05](https://github.com/hidoo/unit-sass/commit/739ef054615c9dd0a9a3bc28b8363a058cb54de5))
-
-
-
-
-
-# [0.7.0](https://github.com/hidoo/unit-sass/compare/v0.6.0...v0.7.0) (2022-01-20)
+# [0.9.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.8.0...v0.9.0) (2023-04-17)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v7.2.0 ([42ec58a](https://github.com/hidoo/unit-sass/commit/42ec58a515f52c9c89d3d19480315b5b99b25be9))
+* **deps:** update dependency fs-extra to v10.1.0 ([86d815e](https://github.com/hidoo/sassdoc-to-markdown/commit/86d815eb4ea15f3c168313132c909d77a8a87c32))
 
 
 
-
-
-# [0.6.0](https://github.com/hidoo/unit-sass/compare/v0.5.0...v0.6.0) (2021-06-09)
-
-**Note:** Version bump only for package @hidoo/sassdoc-to-markdown
-
-
-
-
-
-# [0.5.0](https://github.com/hidoo/unit-sass/compare/v0.4.4...v0.5.0) (2021-06-08)
+# [0.8.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.7.0...v0.8.0) (2022-07-13)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency fs-extra to v10 ([db930a5](https://github.com/hidoo/unit-sass/commit/db930a58f63db1913698fe31d753a6ef97a87ede))
-* **deps:** update dependency glob to v7.1.7 ([ee0999e](https://github.com/hidoo/unit-sass/commit/ee0999e8e366b128c9111c4121398abbf9918530))
+* **deps:** update dependency glob to v7.2.3 ([8dde2db](https://github.com/hidoo/sassdoc-to-markdown/commit/8dde2dbc80e9f55a6744b4a8eed1d34b58ebf176))
+* **deps:** update dependency sassdoc to v2.7.4 ([41900dd](https://github.com/hidoo/sassdoc-to-markdown/commit/41900ddb9854ee23a621cce323e75a1851999b22))
 
 
 
-
-
-## [0.4.4](https://github.com/hidoo/unit-sass/compare/v0.4.2...v0.4.4) (2021-03-31)
-
-
-### Bug Fixes
-
-* **deps:** update dependency fs-extra to v9.0.1 ([f72413e](https://github.com/hidoo/unit-sass/commit/f72413eeeb821834c1e5eea42b71fca78ed97ccb))
-* **deps:** update dependency fs-extra to v9.1.0 ([ae51160](https://github.com/hidoo/unit-sass/commit/ae51160326cd5ab4edd3aff0902b9ffc28e3fa5d))
-* **deps:** update dependency handlebars to v4.7.7 ([ddabfd4](https://github.com/hidoo/unit-sass/commit/ddabfd498cd0d9e9278669b04d6dde86f5c9ab4b))
-* **deps:** update dependency meow to v7 ([eb41854](https://github.com/hidoo/unit-sass/commit/eb4185423ecec6392a9c5451f67b7039e2a68e1e))
-* **deps:** update dependency meow to v7.0.1 ([2b90cf7](https://github.com/hidoo/unit-sass/commit/2b90cf764a203a1e9c157aef1a028cd1d102b29a))
-* **deps:** update dependency meow to v9 ([8e5825d](https://github.com/hidoo/unit-sass/commit/8e5825d2ef438777e0ca3ef1d34470378f0ccb2c))
-* **deps:** update dependency remark to v12.0.1 ([e66822a](https://github.com/hidoo/unit-sass/commit/e66822ab2d01bb273c74f4bc6a58f0c9443e1d03))
-* **deps:** update dependency remark to v13 ([ad1add2](https://github.com/hidoo/unit-sass/commit/ad1add26c6f673fc3ff4f9f523bcc913b67a279f))
-* **deps:** update dependency sassdoc to v2.7.2 ([7633742](https://github.com/hidoo/unit-sass/commit/76337427c587b7759182b65d1fbf7f810c6650eb))
-* **deps:** update dependency sassdoc to v2.7.3 ([e8cafd7](https://github.com/hidoo/unit-sass/commit/e8cafd7fa7070d79828e4a235fd6fe67c16d68f8))
-
-
-
-
-
-## [0.4.3](https://github.com/hidoo/unit-sass/compare/v0.4.2...v0.4.3) (2021-03-31)
+# [0.7.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.6.0...v0.7.0) (2022-01-20)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency fs-extra to v9.0.1 ([f72413e](https://github.com/hidoo/unit-sass/commit/f72413eeeb821834c1e5eea42b71fca78ed97ccb))
-* **deps:** update dependency fs-extra to v9.1.0 ([ae51160](https://github.com/hidoo/unit-sass/commit/ae51160326cd5ab4edd3aff0902b9ffc28e3fa5d))
-* **deps:** update dependency handlebars to v4.7.7 ([ddabfd4](https://github.com/hidoo/unit-sass/commit/ddabfd498cd0d9e9278669b04d6dde86f5c9ab4b))
-* **deps:** update dependency meow to v7 ([eb41854](https://github.com/hidoo/unit-sass/commit/eb4185423ecec6392a9c5451f67b7039e2a68e1e))
-* **deps:** update dependency meow to v7.0.1 ([2b90cf7](https://github.com/hidoo/unit-sass/commit/2b90cf764a203a1e9c157aef1a028cd1d102b29a))
-* **deps:** update dependency meow to v9 ([8e5825d](https://github.com/hidoo/unit-sass/commit/8e5825d2ef438777e0ca3ef1d34470378f0ccb2c))
-* **deps:** update dependency remark to v12.0.1 ([e66822a](https://github.com/hidoo/unit-sass/commit/e66822ab2d01bb273c74f4bc6a58f0c9443e1d03))
-* **deps:** update dependency remark to v13 ([ad1add2](https://github.com/hidoo/unit-sass/commit/ad1add26c6f673fc3ff4f9f523bcc913b67a279f))
-* **deps:** update dependency sassdoc to v2.7.2 ([7633742](https://github.com/hidoo/unit-sass/commit/76337427c587b7759182b65d1fbf7f810c6650eb))
-* **deps:** update dependency sassdoc to v2.7.3 ([e8cafd7](https://github.com/hidoo/unit-sass/commit/e8cafd7fa7070d79828e4a235fd6fe67c16d68f8))
+* **deps:** update dependency glob to v7.2.0 ([a457f97](https://github.com/hidoo/sassdoc-to-markdown/commit/a457f9718f805b1bfda1559e573dbdd19bf3f462))
 
 
 
+# [0.6.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.5.0...v0.6.0) (2021-06-09)
 
 
-## [0.4.2](https://github.com/hidoo/unit-sass/compare/v0.4.1...v0.4.2) (2020-05-08)
+
+# [0.5.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.4.4...v0.5.0) (2021-06-08)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency fs-extra to v9 ([9f79e69](https://github.com/hidoo/unit-sass/commit/9f79e69618f1636c1e66a563524751587b695cd9))
-* **deps:** update dependency handlebars to v4.5.2 ([dbfbe65](https://github.com/hidoo/unit-sass/commit/dbfbe65a165cffb613aadd74865b0f8f29a20bde))
-* **deps:** update dependency handlebars to v4.5.3 ([dc10e9b](https://github.com/hidoo/unit-sass/commit/dc10e9b3fde2ad8cc6f2380729c06c09354c833f))
-* **deps:** update dependency handlebars to v4.7.2 ([9b685de](https://github.com/hidoo/unit-sass/commit/9b685de4da09e5a46591846be2c49381c9a6d0e4))
-* **deps:** update dependency handlebars to v4.7.3 ([4231457](https://github.com/hidoo/unit-sass/commit/4231457283400511ed6e7e4012d61b14dac94dcc))
-* **deps:** update dependency handlebars to v4.7.6 ([bddcd3f](https://github.com/hidoo/unit-sass/commit/bddcd3f27c50c062d097970dfc16c9b6f9fbe1ee))
-* **deps:** update dependency meow to v6 ([927fa06](https://github.com/hidoo/unit-sass/commit/927fa0605302b3de1c49d1660211bdd2e1655915))
-* **deps:** update dependency meow to v6.0.1 ([8ffc641](https://github.com/hidoo/unit-sass/commit/8ffc64182e55eda445e813fd85230e2cf577ecc9))
-* **deps:** update dependency meow to v6.1.0 ([32a43b4](https://github.com/hidoo/unit-sass/commit/32a43b41ba831d38dd6484c0906b406b4192ff18))
-* **deps:** update dependency meow to v6.1.1 ([2e6eb45](https://github.com/hidoo/unit-sass/commit/2e6eb45dc35c9876beed4bd2daa4f29f3d567e84))
-* **deps:** update dependency remark to v12 ([4da3219](https://github.com/hidoo/unit-sass/commit/4da32195bae3ab80476f9fea62fd9b5219b01cb2))
+* **deps:** update dependency fs-extra to v10 ([56b012c](https://github.com/hidoo/sassdoc-to-markdown/commit/56b012c3199491822640e2cc1f5156e7ac30d9ef))
+* **deps:** update dependency glob to v7.1.7 ([9f917bc](https://github.com/hidoo/sassdoc-to-markdown/commit/9f917bc83ac4059ad483310e3a991853aa9bfb41))
 
 
 
+## [0.4.4](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.4.3...v0.4.4) (2021-03-31)
 
 
-## [0.4.1](https://github.com/hidoo/unit-sass/compare/v0.4.0...v0.4.1) (2019-11-11)
+
+## [0.4.3](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.4.2...v0.4.3) (2021-03-31)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency glob to v7.1.5 ([f06e880](https://github.com/hidoo/unit-sass/commit/f06e880))
-* **deps:** update dependency glob to v7.1.6 ([78ddc32](https://github.com/hidoo/unit-sass/commit/78ddc32))
-* **deps:** update dependency handlebars to v4.2.1 ([6ff4556](https://github.com/hidoo/unit-sass/commit/6ff4556))
-* **deps:** update dependency handlebars to v4.3.4 ([ed996b3](https://github.com/hidoo/unit-sass/commit/ed996b3))
-* **deps:** update dependency handlebars to v4.4.0 ([3e85ecd](https://github.com/hidoo/unit-sass/commit/3e85ecd))
-* **deps:** update dependency handlebars to v4.4.2 ([7937ced](https://github.com/hidoo/unit-sass/commit/7937ced))
-* **deps:** update dependency handlebars to v4.4.3 ([72d6aaa](https://github.com/hidoo/unit-sass/commit/72d6aaa))
-* **deps:** update dependency handlebars to v4.4.5 ([4893c3c](https://github.com/hidoo/unit-sass/commit/4893c3c))
-* **deps:** update dependency handlebars to v4.5.1 ([5298f1a](https://github.com/hidoo/unit-sass/commit/5298f1a))
-* **deps:** update dependency remark to v11.0.2 ([95ca4b7](https://github.com/hidoo/unit-sass/commit/95ca4b7))
+* **deps:** update dependency fs-extra to v9.0.1 ([d26c27a](https://github.com/hidoo/sassdoc-to-markdown/commit/d26c27a29268d1b05d5331d4111974b4c689f518))
+* **deps:** update dependency fs-extra to v9.1.0 ([0a8ac2b](https://github.com/hidoo/sassdoc-to-markdown/commit/0a8ac2b7e83180dbf8b3346233bc1666cc29d170))
+* **deps:** update dependency handlebars to v4.7.7 ([eba5d6f](https://github.com/hidoo/sassdoc-to-markdown/commit/eba5d6f1cbd4923e007891fde01937913041db30))
+* **deps:** update dependency meow to v7 ([8b5d37b](https://github.com/hidoo/sassdoc-to-markdown/commit/8b5d37b6afbac13870675f8b3fb0d3c4b0b39083))
+* **deps:** update dependency meow to v7.0.1 ([490cf44](https://github.com/hidoo/sassdoc-to-markdown/commit/490cf446248bfc88174483a54eaf842e0405cf29))
+* **deps:** update dependency meow to v9 ([9b22c52](https://github.com/hidoo/sassdoc-to-markdown/commit/9b22c524aa0c472533d3bf9dbf7d10b11cad1ec1))
+* **deps:** update dependency remark to v12.0.1 ([bfa2566](https://github.com/hidoo/sassdoc-to-markdown/commit/bfa2566301b0e524f633c02d81524634762b8639))
+* **deps:** update dependency remark to v13 ([2e04f58](https://github.com/hidoo/sassdoc-to-markdown/commit/2e04f5803e4c9bf06e5ab91cc1a4f47d2fe7fbfe))
+* **deps:** update dependency sassdoc to v2.7.2 ([6fb75e5](https://github.com/hidoo/sassdoc-to-markdown/commit/6fb75e5432fc9de4c71ccd0a22613beee1f33364))
+* **deps:** update dependency sassdoc to v2.7.3 ([8f5c222](https://github.com/hidoo/sassdoc-to-markdown/commit/8f5c22261f4367306ba38ffc23d0788ed2b00a82))
 
 
 
-
-
-# [0.4.0](https://github.com/hidoo/unit-sass/compare/v0.3.1...v0.4.0) (2019-09-17)
-
-
-### Bug Fixes
-
-* **deps:** update dependency handlebars to v4.2.0 ([8b56846](https://github.com/hidoo/unit-sass/commit/8b56846))
-* **deps:** update dependency sassdoc to v2.7.1 ([d4c460d](https://github.com/hidoo/unit-sass/commit/d4c460d))
-
-
-
-
-
-# [0.3.0](https://github.com/hidoo/unit-sass/compare/v0.2.0...v0.3.0) (2019-08-21)
-
-**Note:** Version bump only for package @hidoo/sassdoc-to-markdown
-
-
-
-
-
-# [0.2.0](https://github.com/hidoo/unit-sass/compare/v0.1.0...v0.2.0) (2019-08-14)
+## [0.4.2](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.4.1...v0.4.2) (2020-05-08)
 
 
 ### Bug Fixes
 
-* **deps:** update dependency remark to v11.0.1 ([082b110](https://github.com/hidoo/unit-sass/commit/082b110))
+* **deps:** update dependency fs-extra to v9 ([51f44df](https://github.com/hidoo/sassdoc-to-markdown/commit/51f44dfc21f63e02fa7dcb1b60d9191e0e48ee61))
+* **deps:** update dependency handlebars to v4.5.2 ([33f2cfd](https://github.com/hidoo/sassdoc-to-markdown/commit/33f2cfdcc0469178105b4366af7ec3f3e0f65840))
+* **deps:** update dependency handlebars to v4.5.3 ([b15e45c](https://github.com/hidoo/sassdoc-to-markdown/commit/b15e45c793255452c26c707aaad88d1a04db2def))
+* **deps:** update dependency handlebars to v4.7.2 ([dd8dd1f](https://github.com/hidoo/sassdoc-to-markdown/commit/dd8dd1f0a8868f03595a51401edfd61392d732d7))
+* **deps:** update dependency handlebars to v4.7.3 ([fc0b478](https://github.com/hidoo/sassdoc-to-markdown/commit/fc0b4780e1153c5aecea97ee0ae1266256bf3413))
+* **deps:** update dependency handlebars to v4.7.6 ([8931100](https://github.com/hidoo/sassdoc-to-markdown/commit/8931100b399f50904386a1aff3fcae574f8ffc19))
+* **deps:** update dependency meow to v6 ([3a54628](https://github.com/hidoo/sassdoc-to-markdown/commit/3a546283dd487766767eef2ac856c401489cae88))
+* **deps:** update dependency meow to v6.0.1 ([08b05c6](https://github.com/hidoo/sassdoc-to-markdown/commit/08b05c6507e52e354f043befd3db8beccdec135f))
+* **deps:** update dependency meow to v6.1.0 ([e0591b6](https://github.com/hidoo/sassdoc-to-markdown/commit/e0591b664dafbb204602354d092b0e40599cd415))
+* **deps:** update dependency meow to v6.1.1 ([bf99c70](https://github.com/hidoo/sassdoc-to-markdown/commit/bf99c706fe24764b71e63dd91017cd025cd21251))
+* **deps:** update dependency remark to v12 ([8c05afc](https://github.com/hidoo/sassdoc-to-markdown/commit/8c05afc3bdca52a66112d00fdf24404308f459b3))
 
 
 
-
-
-# 0.1.0 (2019-08-02)
+## [0.4.1](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.4.0...v0.4.1) (2019-11-11)
 
 
 ### Bug Fixes
 
-* **sassdoc-to-markdown:** fix parameterTable partial ([d48df5d](https://github.com/hidoo/unit-sass/commit/d48df5d))
-* **sassdoc-to-markdown:** fix slug helper ([a03d264](https://github.com/hidoo/unit-sass/commit/a03d264))
-* **sassdoc-to-markdown:** fix sort rules ([d9738ef](https://github.com/hidoo/unit-sass/commit/d9738ef))
-* **sassdoc-to-markdown:** markdown format tweek ([e457e8d](https://github.com/hidoo/unit-sass/commit/e457e8d))
+* **deps:** update dependency glob to v7.1.5 ([3aa5c80](https://github.com/hidoo/sassdoc-to-markdown/commit/3aa5c809fb2cb61e7a85acc69cc6aadf439fa005))
+* **deps:** update dependency glob to v7.1.6 ([937cfae](https://github.com/hidoo/sassdoc-to-markdown/commit/937cfaef4a126099d68cab8563f9e4f61962a8ba))
+* **deps:** update dependency handlebars to v4.2.1 ([d783db5](https://github.com/hidoo/sassdoc-to-markdown/commit/d783db59e04ff80091f88b00ab9b04282f8bfa1c))
+* **deps:** update dependency handlebars to v4.3.4 ([6b04934](https://github.com/hidoo/sassdoc-to-markdown/commit/6b049349500dad991a296926b5cdf9f52d3c75cc))
+* **deps:** update dependency handlebars to v4.4.0 ([e9d7d55](https://github.com/hidoo/sassdoc-to-markdown/commit/e9d7d55d3e41d9fa205e24b782ca69e73e91cc4c))
+* **deps:** update dependency handlebars to v4.4.2 ([60c31f9](https://github.com/hidoo/sassdoc-to-markdown/commit/60c31f9add11022064f32acb57723242088d9e78))
+* **deps:** update dependency handlebars to v4.4.3 ([b85f630](https://github.com/hidoo/sassdoc-to-markdown/commit/b85f6308f6811ca1d78cfbdfcbcb62ea631554d6))
+* **deps:** update dependency handlebars to v4.4.5 ([45245a8](https://github.com/hidoo/sassdoc-to-markdown/commit/45245a849d401b2d52320401f1820aac912a2565))
+* **deps:** update dependency handlebars to v4.5.1 ([0df543c](https://github.com/hidoo/sassdoc-to-markdown/commit/0df543c89aaaf3ca28fabe36278f1543ce2b4209))
+* **deps:** update dependency remark to v11.0.2 ([50ea80e](https://github.com/hidoo/sassdoc-to-markdown/commit/50ea80e87560beca1c1f563417d7aaf107a9ce2c))
+
+
+
+# [0.4.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.3.0...v0.4.0) (2019-09-17)
+
+
+### Bug Fixes
+
+* **deps:** update dependency handlebars to v4.2.0 ([2c9f0fe](https://github.com/hidoo/sassdoc-to-markdown/commit/2c9f0fe60b56c158029ece0f96726b8f0bb12e78))
+* **deps:** update dependency sassdoc to v2.7.1 ([363612b](https://github.com/hidoo/sassdoc-to-markdown/commit/363612b64fbbc6a1b714cb8d842adf2e7479ed4c))
+
+
+
+# [0.3.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.2.0...v0.3.0) (2019-08-21)
+
+
+
+# [0.2.0](https://github.com/hidoo/sassdoc-to-markdown/compare/v0.1.0...v0.2.0) (2019-08-14)
+
+
+### Bug Fixes
+
+* **deps:** update dependency remark to v11.0.1 ([1676f08](https://github.com/hidoo/sassdoc-to-markdown/commit/1676f084ac6d1f20bbf53c114eba4ec76f36e48b))
+
+
+
+# [0.1.0](https://github.com/hidoo/sassdoc-to-markdown/compare/ea37c1364623aa0f0ae56e5ef233b1fb6686641a...v0.1.0) (2019-08-02)
+
+
+### Bug Fixes
+
+* **sassdoc-to-markdown:** fix parameterTable partial ([9e0b542](https://github.com/hidoo/sassdoc-to-markdown/commit/9e0b5428061d3379a079955a9101c04603f656c1))
+* **sassdoc-to-markdown:** fix slug helper ([1197a06](https://github.com/hidoo/sassdoc-to-markdown/commit/1197a060ae505ebdfdb5b9ae45ac98bb60b9af98))
+* **sassdoc-to-markdown:** fix sort rules ([a836d73](https://github.com/hidoo/sassdoc-to-markdown/commit/a836d73d61a4488247fbc3a5c939e35d9ea0a173))
+* **sassdoc-to-markdown:** markdown format tweek ([6475fa8](https://github.com/hidoo/sassdoc-to-markdown/commit/6475fa8ecc7d344944a40e175295a305ffeaac21))
 
 
 ### Features
 
-* **sassdoc-to-markdown:** add tool that build markdown docs use sassdoc ([db01c4d](https://github.com/hidoo/unit-sass/commit/db01c4d))
+* **sassdoc-to-markdown:** add tool that build markdown docs use sassdoc ([ea37c13](https://github.com/hidoo/sassdoc-to-markdown/commit/ea37c1364623aa0f0ae56e5ef233b1fb6686641a))
+
+
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Test](https://github.com/hidoo/sassdoc-to-markdown/actions/workflows/test.yml/badge.svg)](https://github.com/hidoo/sassdoc-to-markdown/actions/workflows/test.yml)
 
-> Generate markdown document use SassDoc.
+> Generate markdown documentation from SassDoc comments.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/sassdoc-to-markdown",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Generate markdown documentation from SassDoc comments.",
   "packageManager": "pnpm@9.0.6",
   "engines": {


### PR DESCRIPTION
### BREAKING CHANGES

* Requires ES Modules.
* Drop Node.js 14.x and 16.x support. 
* Remove `remarkParserOption` and add `remarkGfmOptions` in options of sassdoc2md.
